### PR TITLE
Add docker labels to have update tools be able to pull changelog/release notes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -218,3 +218,5 @@ VOLUME /var/lib/pgadmin
 EXPOSE 80 443
 
 ENTRYPOINT ["/entrypoint.sh"]
+ARG APP_RELEASE
+LABEL org.opencontainers.image.source="https://github.com/dpage/pgadmin4/" org.opencontainers.image.revision=${APP_RELEASE}

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ debian:
 
 docker:
 	echo $(APP_NAME)
-	docker build --pull -t ${APP_NAME} -t $(APP_NAME):latest -t $(APP_NAME):$(APP_RELEASE) -t $(APP_NAME):$(APP_RELEASE).$(APP_REVISION) .
+	docker build --pull --build-arg APP_RELEASE=$(APP_RELEASE) -t ${APP_NAME} -t $(APP_NAME):latest -t $(APP_NAME):$(APP_RELEASE) -t $(APP_NAME):$(APP_RELEASE).$(APP_REVISION) .
 
 docs:
 	LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 $(MAKE) -C docs/en_US -f Makefile.sphinx html


### PR DESCRIPTION
For example https://docs.renovatebot.com/modules/datasource/docker/

but other tools will pull those same labels

I took a stab that you update the docker images via the make file, i couldn't find anything in github actions. Lemme know if there's a better way to set those labels/args